### PR TITLE
Add expense editing option

### DIFF
--- a/src/Context/FireContext.jsx
+++ b/src/Context/FireContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useContext } from 'react';
 import { db } from "../components/firebase/firestore";
-import { collection, getDocs, getDoc, doc, query, addDoc, deleteDoc} from "firebase/firestore";
+import { collection, getDocs, getDoc, doc, query, addDoc, deleteDoc, updateDoc } from "firebase/firestore";
 import { AuthContext } from '../Context/AuthContext';
 
 export const FireContext = createContext();
@@ -73,6 +73,25 @@ export default function FireProvider({children}){
         }
     };
 
+    const updateEntry = async (docId, newAmount) => {
+
+        if (cUser && cUser.uid){
+            const uid = cUser.uid;
+
+            const docRef = doc(db, "expenses", uid, "monthly", docId);
+
+            try {
+                await updateDoc(docRef, { amount: newAmount });
+                fetchData();
+                const today = new Date().getTime()/1000;
+                updateCValue(today);
+            } catch (err) {
+                console.log(err.message);
+            }
+
+        }
+    };
+
     const isThisMonth = (i, date) => {
         const today = new Date(0);
         today.setUTCSeconds(date);
@@ -90,7 +109,7 @@ export default function FireProvider({children}){
     }; 
 
     return (
-        <FireContext.Provider value={{dataArr, cValue, filteredArr, updateCValue, fetchData, isThisMonth, filterDataArr, names, deleteEntry}}>
+        <FireContext.Provider value={{dataArr, cValue, filteredArr, updateCValue, fetchData, isThisMonth, filterDataArr, names, deleteEntry, updateEntry}}>
             {children}
         </FireContext.Provider>
     )

--- a/src/components/body/Detailedview.jsx
+++ b/src/components/body/Detailedview.jsx
@@ -5,7 +5,7 @@ import { FireContext } from "../../Context/FireContext";
 
 export default function Detailedview({name, amount, date, note, category, nonSplit, docId}) {
 
-    const { names, deleteEntry } = useContext(FireContext);
+    const { names, deleteEntry, updateEntry } = useContext(FireContext);
 
     const expDate = new Date(0);
     expDate.setUTCSeconds(date);
@@ -15,6 +15,8 @@ export default function Detailedview({name, amount, date, note, category, nonSpl
     const formatedDate = dd + "/" + mm + "/" + yy;
 
     const [optionsView, setOptionsView] = useState();
+    const [editMode, setEditMode] = useState(false);
+    const [newAmount, setNewAmount] = useState(amount);
 
     let optionsIcon = "▼";
     let expenseIcon = "";
@@ -48,7 +50,7 @@ export default function Detailedview({name, amount, date, note, category, nonSpl
             <img className="expenseIcon" src={expenseIcon} alt="" />
             <div style={{display:"flex", flexDirection:"column", alignItems:"center"}}>
                 <p style={{borderBottom:"1px solid white", marginBottom:-5}}>{formatedDate} - <strong>{name}</strong></p>
-                <p>{amount}€ on {category ? category : "Supermarket"}</p>
+                <p>{newAmount}€ on {category ? category : "Supermarket"}</p>
                 <div style={{display:"flex", flexDirection:"column", alignItems:"center", justifyContent:"center"}}>
                     {note ? <p style={{marginTop:"-5px", textAlign:"center"}}>Note: {note}</p> : ""}
                     {nonSplit === true ? <p style={{marginTop:"-5px", textAlign:"center", color:"RGB(70,61,134)", backgroundColor:"white", width:"90%", fontWeight:700, borderRadius:"2px"}}>Purchase made for the other user</p> : ""}
@@ -56,7 +58,18 @@ export default function Detailedview({name, amount, date, note, category, nonSpl
                 <div>
                     <button style={{backgroundColor:"LightGray", border:"none", color:"black", borderRadius:"2px", minWidth:"40px"}} onClick={()=>{optionsView === false ? setOptionsView(true) : setOptionsView(false)}}>{optionsIcon}</button>
                 </div>
-                {optionsView && <button style={{backgroundColor:"#f44336", border:"none", color:"white", marginTop:"20px", marginBottom:"5px", borderRadius:"2px"}} onClick={()=>{deleteEntry(docId)}}>Delete entry</button>}
+                {optionsView && (
+                    <>
+                        <button style={{backgroundColor:"#1DE9B6", border:"none", color:"#263238", marginTop:"20px", marginBottom:"5px", borderRadius:"2px", marginRight:"5px"}} onClick={()=>setEditMode(!editMode)}>Edit amount</button>
+                        <button style={{backgroundColor:"#f44336", border:"none", color:"white", marginTop:"20px", marginBottom:"5px", borderRadius:"2px"}} onClick={()=>{deleteEntry(docId)}}>Delete entry</button>
+                    </>
+                )}
+                {editMode && (
+                    <div style={{display:"flex", alignItems:"center", marginTop:"10px"}}>
+                        <input type="number" value={newAmount} onChange={(e)=>setNewAmount(e.target.value)} style={{width:"60px", marginRight:"5px"}} />
+                        <button style={{backgroundColor:"#1DE9B6", border:"none", color:"#263238", borderRadius:"2px"}} onClick={()=>{updateEntry(docId, newAmount); setEditMode(false); setOptionsView(false);}}>Save</button>
+                    </div>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary
- add `updateEntry` in FireContext to modify Firestore doc
- allow users to edit expense amount in `Detailedview`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406811e40883219eebc2965ba69cc6